### PR TITLE
added `data` dir and `findserver` file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ data/analysis/
 data/images/
 documentation/site
 find
+findserver
 
 __pycache__/
 www/sphinx-api/_build/
@@ -76,6 +77,7 @@ nohup.out
 # Databases
 *.db.*
 *.db
+data/*
 
 # Data
 *.p


### PR DESCRIPTION
When running tests or building locally, `findserver` is created, and the `data` dir is populated with test data. These should be ignored in the repo.