### PR TITLE
Support external MQTT servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN go build -v
 RUN echo "\ninclude_dir /usr/local/work/src/github.com/schollz/find/mosquitto" >> /etc/mosquitto/mosquitto.conf
 
 # Setup supervisor
-RUN apt-get update 
+RUN apt-get update
 RUN apt-get install -y supervisor
 
 # Add supervisor
@@ -53,6 +53,9 @@ ENV TINI_VERSION v0.13.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--"]
+
+# Default MQTT connection settings
+ENV MQTT_SERVER=localhost:1883 MQTT_USERNAME=admin MQTT_PASSWORD=123
 
 # Startup
 CMD ["/usr/bin/supervisord"]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -11,7 +11,7 @@ stderr_logfile_maxbytes=0
 
 [program:findserver]
 directory=/usr/local/work/src/github.com/schollz/find
-command=/usr/local/work/src/github.com/schollz/find/find -rf 5009 -mqtt localhost:1883 -mqttadmin admin -mqttadminpass 123 -mosquitto `pgrep mosquitto` -data /data
+command=/usr/local/work/src/github.com/schollz/find/find -rf 5009 -mqtt %(ENV_MQTT_SERVER)s -mqttadmin %(ENV_MQTT_USERNAME)s -mqttadminpass %(ENV_MQTT_PASSWORD)s -mosquitto `pgrep mosquitto` -data /data
 priority=999
 stdout_logfile=/usr/local/work/src/github.com/schollz/find/log.out
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
This PR allows settings `MQTT_SERVER`, `MQTT_USERNAME` and `MQTT_PASSWORD` on runtime thus permitting to use an MQTT server other than the bundled one.

Usage example:
```bash
docker run --name find-server -p 8003:8003 \
  -e MQTT_SERVER=mqtt.example.com \
  -e MQTT_USERNAME=find \
  -e MQTT_PASSWORD=dasdaqsed324 \
  schollz/find
```